### PR TITLE
Fixed warning about room schema location

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -43,6 +43,9 @@ android {
 
 kapt {
     correctErrorTypes = true
+    arguments {
+        arg("room.schemaLocation", "$projectDir/schemas")
+    }
 }
 
 dependencies {


### PR DESCRIPTION
# Description

Added argument to `build.gradle` to fix room schema warning

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Screenshots:

n/a